### PR TITLE
Restrict access to Focal Point Dashboard and Reduce Bundle Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Only show the CAFTOPs link to those with the Focal Point role
+- Removed PnPJS imports that aren't used by this application
 
 ## [1.0.1] - 2024-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed for any bug fixes.
 - Security in case of vulnerabilities.
 
-## [1.0.1]
+## [1.0.2] - 2025-01-25
+
+### Changed
+
+- Only show the CAFTOPs link to those with the Focal Point role
+
+## [1.0.1] - 2024-12-31
 
 - Refactor MILSTD3048 Zod rules for better typescript support
 
-## [1.0.0]
+## [1.0.0] - 2024-12-23
 
 - Initial release of the CAFTOP Narrative Tool
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ If you are developing a production application, we recommend updating the config
 - Custom permission levels
   - CAFTOPItemLevel - Contribue plus Approve Items for use at Item Level
 
+Note: The application looks for a group name that ends with "Focal Points" to determine whether or not to show the link
+
 ## PowerAutomate setuup
 
 - Ensure the trigger action has the following trigger condition, which will ensure it only fires when needed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caftop",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caftop",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@fluentui/example-data": "^8.4.25",
         "@fluentui/react": "^8.120.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caftop",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/api/RolesApi.ts
+++ b/src/api/RolesApi.ts
@@ -1,0 +1,57 @@
+import { ISiteGroupInfo } from "@pnp/sp/site-groups/types";
+import { spWebContext } from "@api/SPWebContext";
+import { useQuery } from "@tanstack/react-query";
+
+export interface IRoles {
+  isFocalPoint: boolean;
+}
+
+const transformGroups = (data: ISiteGroupInfo[]): IRoles => {
+  const isFocalPoint = data.find((value) =>
+    value.Title.endsWith("Focal Points")
+  )
+    ? true
+    : false;
+
+  const roles = {
+    isFocalPoint: isFocalPoint,
+  };
+
+  return roles;
+};
+
+const getRoles = () => {
+  if (!import.meta.env.DEV) {
+    return spWebContext.web.currentUser.groups();
+  } else {
+    const groups: ISiteGroupInfo[] = [
+      {
+        Title: "CAFTOP Narrative Focal Points",
+        AllowMembersEditMembership: false,
+        AllowRequestToJoinLeave: false,
+        AutoAcceptRequestToJoinLeave: false,
+        Description: "",
+        Id: 0,
+        IsHiddenInUI: false,
+        LoginName: "",
+        OnlyAllowMembersViewMembership: false,
+        OwnerTitle: "",
+        PrincipalType: 0,
+        RequestToJoinLeaveEmailSetting: null,
+      },
+    ];
+    return new Promise<ISiteGroupInfo[]>((resolve) =>
+      setTimeout(() => resolve(groups), 1000)
+    );
+  }
+};
+
+export const useMyRoles = () => {
+  return useQuery({
+    queryKey: ["roles"],
+    queryFn: getRoles,
+    staleTime: Infinity,
+    cacheTime: Infinity,
+    select: transformGroups,
+  });
+};

--- a/src/api/SPWebContext.ts
+++ b/src/api/SPWebContext.ts
@@ -1,19 +1,8 @@
 import { spfi, SPBrowser } from "@pnp/sp";
-import "@pnp/sp/content-types/list";
 import "@pnp/sp/webs";
-import "@pnp/sp/lists";
 import "@pnp/sp/lists/web";
-import "@pnp/sp/items";
 import "@pnp/sp/items/list";
 import "@pnp/sp/site-users/web";
-import "@pnp/sp/site-groups/web";
-import "@pnp/sp/profiles";
-import "@pnp/sp/batching";
-import "@pnp/sp/folders";
-import "@pnp/sp/files";
-import "@pnp/sp/files/folder";
-import "@pnp/sp/files/web";
-import "@pnp/sp/comments/item";
 import "@pnp/sp/profiles";
 import { getSPUserProfileDataDev } from "@api/SPSampleUserData";
 

--- a/src/api/SPWebContext.ts
+++ b/src/api/SPWebContext.ts
@@ -6,6 +6,7 @@ import "@pnp/sp/lists/web";
 import "@pnp/sp/items";
 import "@pnp/sp/items/list";
 import "@pnp/sp/site-users/web";
+import "@pnp/sp/site-groups/web";
 import "@pnp/sp/profiles";
 import "@pnp/sp/batching";
 import "@pnp/sp/folders";

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -11,6 +11,7 @@ import { UserContext } from "@providers/UserProvider";
 import { tokens } from "@fluentui/react-theme";
 import { Link } from "react-router-dom";
 import { useDefaultHelpLink } from "@api/DefaultData";
+import { useMyRoles } from "@api/RolesApi";
 
 /* FluentUI Styling */
 const useStyles = makeStyles({
@@ -63,6 +64,7 @@ export const AppHeader = () => {
   const classes = useStyles();
   const userContext = useContext(UserContext);
   const helpLink = useDefaultHelpLink();
+  const myRoles = useMyRoles();
 
   const title =
     import.meta.env.MODE === "testing" || import.meta.env.DEV
@@ -75,9 +77,11 @@ export const AppHeader = () => {
         <Link to="/" className={classes.navHeaderSiteName}>
           {title}
         </Link>
-        <Link to="/CAFTOPs" className={classes.navLink}>
-          CAFTOPs
-        </Link>
+        {myRoles.data?.isFocalPoint && (
+          <Link to="/CAFTOPs" className={classes.navLink}>
+            CAFTOPs
+          </Link>
+        )}
         <Link to={helpLink} className={classes.navHelp} target="_blank">
           Help
         </Link>
@@ -101,23 +105,22 @@ export const AppHeader = () => {
             </Tooltip>
           </PopoverTrigger>
           <PopoverSurface aria-label="Your roles">
-            {/** If the user has role(s), list them */
-            /*userContext.roles && userContext.roles.length > 0 && (
+            {
+              /* If user is a Focal Point */
+              myRoles.data?.isFocalPoint && (
                 <ul>
-                  {userContext.roles?.map((role) => (
-                    <li key={role}>{role}</li>
-                  ))}
+                  <li key="focalPoint">Focal Point</li>
                 </ul>
-              )*/}
-            {/** If the user has no privleged role(s), just state standard account */
-            /*userContext.roles && userContext.roles.length === 0 && (
+              )
+            }
+            {
+              /* If the user has no privleged role(s), just state standard account */
+              !myRoles.data?.isFocalPoint && (
                 <ul>
                   <li>Standard user account</li>
                 </ul>
-              )*/}
-            <ul>
-              <li>Standard user account</li>
-            </ul>
+              )
+            }
           </PopoverSurface>
         </Popover>
       </div>

--- a/src/components/FPDashboard/FPDashboard.tsx
+++ b/src/components/FPDashboard/FPDashboard.tsx
@@ -36,7 +36,8 @@ import {
 import { useCallback, useRef, useState } from "react";
 import { FilterIcon } from "@fluentui/react-icons-mdl2";
 import FilterRequestsDrawer from "./Filter";
-import { useNavigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
+import { useMyRoles } from "@api/RolesApi";
 
 const Year = createTableColumn<PagedRequest>({
   columnId: "Year",
@@ -136,6 +137,7 @@ const FPDashboard = () => {
       ProgramName: { minWidth: 60, idealWidth: 280 },
     });
   const [drawerIsOpen, setDrawerIsOpen] = useState(false);
+  const myRoles = useMyRoles();
 
   const onColumnResize = useCallback(
     (
@@ -177,6 +179,16 @@ const FPDashboard = () => {
     ProgramGroup,
     ProgramName,
   ];
+
+  // Render "Loading" if we are still waiting to determine if user is authorized this page
+  if (myRoles.isLoading) {
+    return <>Loading</>;
+  }
+
+  // If roles have loaded, and user is not a Focal Point, then send them back to the Homepage
+  if (!myRoles.data?.isFocalPoint) {
+    return <Navigate to={"/"} />;
+  }
 
   // RENDER
   return (


### PR DESCRIPTION
Limit access to the CAFTOP Focal Point Dashboard, to only those users who are in a group that ends with "Focal Points".

Reduce the bundle size, by removing unused PnPJS selective imports.