### PR TITLE
Ensure new maxSteps get saved

### DIFF
--- a/src/Steps/Steps.tsx
+++ b/src/Steps/Steps.tsx
@@ -171,7 +171,8 @@ export const CAFTOPWizardSteps = (props: ICAFTOPWizardSteps) => {
         navAction = () => dispatch({ type: "PREV_STEP" });
       }
     }
-    if (hasChanges) {
+    // If they changed data OR if they are moving to the next step which needs to become the new max step
+    if (hasChanges || isSaveAndContinue) {
       if (!isSaveAndContinue) {
         // Prompt to save changes if it isn't the "Save and Continue" button -- as that implies Save
         setNavChanges(hasChanges);


### PR DESCRIPTION
While updating to increase effeciency, and not save if no data was changed, it was also not saving if they were unlocking the next max step without updating data. This fixes that issue by saving if they are reaching a new max step.