### PR TITLE
Fix wizardMaxStep to not reset to lower step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed for any bug fixes.
 - Security in case of vulnerabilities.
 
+## [1.0.3] - 2025-02-13
+
+### Fixed
+
+- wizardMaxStep could be moved down in number under certain circumstances, as it was comparing to cached wizardMaxStep, instead of the one being incremented in the session
+
 ## [1.0.2] - 2025-01-25
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "caftop",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "caftop",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@fluentui/example-data": "^8.4.25",
         "@fluentui/react": "^8.120.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "caftop",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite --open",

--- a/src/Steps/Steps.tsx
+++ b/src/Steps/Steps.tsx
@@ -147,7 +147,7 @@ export const CAFTOPWizardSteps = (props: ICAFTOPWizardSteps) => {
       if (e.nativeEvent?.submitter?.id === "next") {
         isSaveAndContinue = globalState.wizardMaxStep === props.currentStep;
         saveAction = async () => {
-          if (props.currentStep + 1 > (maxStep.data?.wizardMaxStep ?? 0)) {
+          if (props.currentStep + 1 > globalState.wizardMaxStep) {
             Object.assign(data, {
               wizardMaxStep: props.currentStep + 1,
             });


### PR DESCRIPTION
Compare to the globalState.wizardMaxStep, as it is updated as it progresses, rather than to the max step that is querired from the record on load and not reloaded unless changing CAFTOPs